### PR TITLE
Added link to an initial data catalog for explore + download

### DIFF
--- a/app/data/template.hbs
+++ b/app/data/template.hbs
@@ -22,7 +22,11 @@
     {{/each}}
   </div>
 
+  <div class="layer-listing">
+    <a class="btn btn-default btn-lg btn-show-more" href="http://prepdata.sdgs.opendata.arcgis.com/">Download Data</a>
+  </div>
 </div>
+
 <div id="search"></div>
 
 {{legend-view}}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "author": "",
   "license": "MIT",
+  "dependencies": {
+        "bootstrap-sass": "3.3.6"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
     "broccoli-funnel": "^1.0.1",


### PR DESCRIPTION
To assist in the registration and discovery of data, we configured a [Prep Open Data Site](http://prepdata.sdgs.opendata.arcgis.com/). This PR adds a simple link from the prototype to explore this catalog.


<img width="1257" alt="prepprototype" src="https://cloud.githubusercontent.com/assets/1218/15680044/1d7faf3c-2722-11e6-853f-226518aeb7c8.png">

<img width="1271" alt="home___preparedness_for_resilience__climate_data" src="https://cloud.githubusercontent.com/assets/1218/15680053/260c75b8-2722-11e6-9018-4c6ddd7b1b7a.png">

<img width="1254" alt="search_for_____preparedness_for_resilience__climate_data" src="https://cloud.githubusercontent.com/assets/1218/15680070/3513d268-2722-11e6-9cae-b73a3de8a337.png">
